### PR TITLE
Added option to override GOOGLE_CHROME detection; eg. for Chromium users (reopened #113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+binary_name

--- a/browser-ext/login/Makefile
+++ b/browser-ext/login/Makefile
@@ -10,7 +10,10 @@ CFX=$(BUILD_DIR)/../../third_party/firefox-addon-sdk/bin/cfx
 
 CLOSURE_STRICT_FLAGS=--language_in ECMASCRIPT5_STRICT --warning_level VERBOSE --compilation_level ADVANCED_OPTIMIZATIONS --externs externs_node.js --jscomp_error missingProperties --jscomp_error checkTypes --jscomp_error checkRegExp --jscomp_error accessControls --jscomp_error const --jscomp_error missingReturn
 
-ifeq ($(shell uname),Darwin)
+ifneq ($(shell cat binary_name),)
+  GOOGLE_CHROME=$(shell cat binary_name)
+  $(info Found binary_name file; Setting $$GOOGLE_CHROME to [${GOOGLE_CHROME}])
+else ifeq ($(shell uname),Darwin)
   GOOGLE_CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 else
   GOOGLE_CHROME=google-chrome


### PR DESCRIPTION
This is useful for people who's binary is not google-chrome, eg. chromium users, or users of ArchLinux
(there GOOGLE_CHROME should be "google-chrome-stable").
